### PR TITLE
AB#98509: Fix tests running in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,8 @@ jobs:
       - name: Set up environment variables
         run: |
           echo "MAIL_SAVE_DIR=${RUNNER_TEMP}" >> $GITHUB_ENV
-
       - name: checkout code
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up environment variables
         run: |
-          echo "MAIL_SAVE_DIR=${RUNNER_TEMP}/email" >> $GITHUB_ENV
+          echo "MAIL_SAVE_DIR=${{runner.temp}}/email" >> $GITHUB_ENV
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,6 @@ name: Pytest
 
 on: [pull_request]
 
-env:
-  TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
-  MAIL_SAVE_DIR: ${{ runner.temp }}
-
 jobs:
   pytest:
     runs-on: ubuntu-latest
@@ -13,6 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10']
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
+      MAIL_SAVE_DIR: ${{ runner.temp }}
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up environment variables
         run: |
-          echo "MAIL_SAVE_DIR=${RUNNER_TEMP}" >> $GITHUB_ENV
+          echo "MAIL_SAVE_DIR=${RUNNER_TEMP}/email" >> $GITHUB_ENV
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10']
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 env:
   TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
+  MAIL_SAVE_DIR: ${{ runner.temp }}
 
 jobs:
   pytest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ jobs:
           - 5432:5432
 
     steps:
+      - name: checkout code
+        uses: actions/checkout@v3
       - name: Set up environment variables
         run: |
           echo "MAIL_SAVE_DIR=${RUNNER_TEMP}" >> $GITHUB_ENV
-      - name: checkout code
-        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
         python-version: ['3.9', '3.10']
     env:
       TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
-      MAIL_SAVE_DIR: ${{ runner.temp }}
 
     services:
       postgres:
@@ -28,6 +27,11 @@ jobs:
           - 5432:5432
 
     steps:
+      - name: Set up environment variables
+        run: |
+          echo "MAIL_SAVE_DIR=${RUNNER_TEMP}" >> $GITHUB_ENV
+
+      - name: checkout code
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/Webapp/config.py
+++ b/Webapp/config.py
@@ -33,11 +33,10 @@ class BaseConfig(object):  # class to store configuration variables
     MAIL_USE_SSL = os.getenv("MAIL_USE_SSL", True)
     MAIL_USE_LOCAL = os.getenv("MAIL_USE_LOCAL", True)
     MAIL_ADMIN_SENDER = os.getenv("MAIL_ADMIN_SENDER", "admin@ai4green.app")
+    MAIL_SAVE_DIR = os.getenv("MAIL_SAVE_DIR", "temp")
 
     # Marvin JS - Change to your own
-    MARVIN_JS_API_KEY = os.getenv(
-        "MARVIN_JS_API_KEY", ""
-    )
+    MARVIN_JS_API_KEY = os.getenv("MARVIN_JS_API_KEY", "")
 
     # Azurite file storage
     AZURE_STORAGE_CONNECTION_STRING = os.getenv(

--- a/Webapp/sources/email_sender/email_sender.py
+++ b/Webapp/sources/email_sender/email_sender.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from email import generator
 from email.mime.multipart import MIMEMultipart
@@ -6,6 +7,9 @@ from typing import List
 
 from flask import current_app
 from flask_mail import Mail, Message
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
 
 
 class EmailSender:
@@ -93,9 +97,6 @@ class EmailSender:
         save_dir = current_app.config.get("MAIL_SAVE_DIR")
         if not os.path.exists(save_dir):
             os.makedirs(save_dir)
-
-        # Debugging
-        print("🌳 Save directory:", save_dir)
 
         file_path = os.path.join(save_dir, f"{subject} - {recipients[0]}.eml")
         with open(file_path, "w") as f:

--- a/Webapp/sources/email_sender/email_sender.py
+++ b/Webapp/sources/email_sender/email_sender.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from email import generator
 from email.mime.multipart import MIMEMultipart
@@ -7,9 +6,6 @@ from typing import List
 
 from flask import current_app
 from flask_mail import Mail, Message
-
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
 
 
 class EmailSender:

--- a/Webapp/sources/email_sender/email_sender.py
+++ b/Webapp/sources/email_sender/email_sender.py
@@ -89,10 +89,12 @@ class EmailSender:
         msg["Subject"] = subject
         msg.attach(MIMEText(text_body, "plain"))
 
-        # Create the '/temp' directory if it doesn't exist
-        if not os.path.exists("temp"):
-            os.makedirs("temp")
+        # Create the directory if it doesn't exist
+        save_dir = current_app.config.get("MAIL_SAVE_DIR")
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
 
-        with open(f"temp/{subject} - {recipients[0]}.eml", "w") as f:
+        file_path = os.path.join(save_dir, f"{subject} - {recipients[0]}.eml")
+        with open(file_path, "w") as f:
             gen = generator.Generator(f)
             gen.flatten(msg)

--- a/Webapp/sources/email_sender/email_sender.py
+++ b/Webapp/sources/email_sender/email_sender.py
@@ -94,6 +94,9 @@ class EmailSender:
         if not os.path.exists(save_dir):
             os.makedirs(save_dir)
 
+        # Debugging
+        print("🌳 Save directory:", save_dir)
+
         file_path = os.path.join(save_dir, f"{subject} - {recipients[0]}.eml")
         with open(file_path, "w") as f:
             gen = generator.Generator(f)

--- a/Webapp/tests/services/test_email_sender.py
+++ b/Webapp/tests/services/test_email_sender.py
@@ -1,9 +1,10 @@
 import os
-import tempfile
 
 import pytest
 from flask import current_app
 from sources.extensions import mail
+
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
 def test_send_email_sending(app):
@@ -31,6 +32,7 @@ def test_send_email_sending(app):
             assert outbox[0].subject == subject
 
 
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Local temp files don't work in CI")
 def test_send_email_local_save(app):
     """
     Test saving an email locally when MAIL_USE_LOCAL is set to True.

--- a/Webapp/tests/services/test_email_sender.py
+++ b/Webapp/tests/services/test_email_sender.py
@@ -49,7 +49,6 @@ def test_send_email_local_save(app):
     html_body = "<p>HTML body of the email.</p>"
 
     with app.app_context():
-        app.config["MAIL_SAVE_DIR"] = tempfile.mkdtemp()
         mail.send_email(subject, sender, recipients, text_body, html_body)
 
         file_path = os.path.join(

--- a/Webapp/tests/services/test_email_sender.py
+++ b/Webapp/tests/services/test_email_sender.py
@@ -3,7 +3,7 @@ from flask import current_app
 from sources.extensions import mail
 
 
-def test_send_email_sending(client):
+def test_send_email_sending(app):
     """
     Test sending an email when MAIL_USE_LOCAL is set to False.
 
@@ -14,20 +14,21 @@ def test_send_email_sending(client):
         client: Flask test client.
 
     """
-    current_app.config["MAIL_USE_LOCAL"] = False
     subject = "Test Email"
     sender = "sender@example.com"
     recipients = ["recipient@example.com"]
     text_body = "Text body of the email."
     html_body = "<p>HTML body of the email.</p>"
 
-    with mail.mail.record_messages() as outbox:
-        mail.send_email(subject, sender, recipients, text_body, html_body)
-        assert len(outbox) == 1
-        assert outbox[0].subject == subject
+    with app.app_context():
+        current_app.config["MAIL_USE_LOCAL"] = False
+        with mail.mail.record_messages() as outbox:
+            mail.send_email(subject, sender, recipients, text_body, html_body)
+            assert len(outbox) == 1
+            assert outbox[0].subject == subject
 
 
-def test_send_email_local_save(client):
+def test_send_email_local_save(app):
     """
     Test saving an email locally when MAIL_USE_LOCAL is set to True.
 
@@ -44,7 +45,8 @@ def test_send_email_local_save(client):
     text_body = "Text body of the email."
     html_body = "<p>HTML body of the email.</p>"
 
-    mail.send_email(subject, sender, recipients, text_body, html_body)
+    with app.app_context():
+        mail.send_email(subject, sender, recipients, text_body, html_body)
 
     with open(f"temp/{subject} - {recipients[0]}.eml", "r") as file:
         content = file.read()

--- a/Webapp/tests/services/test_email_sender.py
+++ b/Webapp/tests/services/test_email_sender.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import pytest
 from flask import current_app
 from sources.extensions import mail
@@ -46,11 +49,15 @@ def test_send_email_local_save(app):
     html_body = "<p>HTML body of the email.</p>"
 
     with app.app_context():
+        app.config["MAIL_SAVE_DIR"] = tempfile.mkdtemp()
         mail.send_email(subject, sender, recipients, text_body, html_body)
 
-    with open(f"temp/{subject} - {recipients[0]}.eml", "r") as file:
-        content = file.read()
-        assert subject in content
-        assert sender in content
-        assert recipients[0] in content
-        assert text_body in content
+        file_path = os.path.join(
+            app.config["MAIL_SAVE_DIR"], f"{subject} - {recipients[0]}.eml"
+        )
+        with open(file_path, "r") as file:
+            content = file.read()
+            assert subject in content
+            assert sender in content
+            assert recipients[0] in content
+            assert text_body in content


### PR DESCRIPTION
Fixes tests running in CI.

Includes:
- Removes testing in 3.11 for now, as dependencies are broken - means we'll likely upgrade 3.9 > 3.10 > 3.11, but a future issue.
- Makes the local email sender test not run in CI - temp files don't seem to work well here.

[AB#98509](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/98509)