### PR TITLE
AB#130121: File viewing and permissions for file handling fixed

### DIFF
--- a/Webapp/sources/static/js/reaction_table/autosave.js
+++ b/Webapp/sources/static/js/reaction_table/autosave.js
@@ -239,18 +239,8 @@ function postReactionData(complete='not complete') {
                     autoChangeRequiredStyling2("#js-unreacted-reactant-mass")
                     $("#js-real-product-mass").removeClass("add-highlight-unfilled-cell").addClass("remove-highlight-summary-cell");
                     $("#js-unreacted-reactant-mass").removeClass("add-highlight-unfilled-cell").addClass("remove-highlight-summary-cell");
-                    $("#page-contents :input").prop("disabled", true);
                     $("#js-complete").val('complete')
-                    $("#complete-reaction-button").prop('disabled', true)
-                    // lock editor
-                    if (ifCurrentUserIsNotCreator()){
-                        $("#marvin-test").css("pointer-events", "none");
-                    }
-                    // do not lock print
-                    $("#print-pdf").prop("disabled", false);
-                    // show and enable add note button and reactionNote modal window
-                    $("#reaction-note-button").show().prop("disabled", false);
-                    $("#new-reaction-note-modal").find("*").prop("disabled", false);
+                    controlLockedReactionFunctionality()
                 }
             } else {
                 // if not locking reaction save as normal
@@ -261,6 +251,31 @@ function postReactionData(complete='not complete') {
             flashUserErrorSavingMessage()
         }
     })
+}
+
+/**
+ * Disables page contents and buttons outside of page contents div
+ * Enables specific buttons for locked reactions.
+ * Upload, view, delete files. Print summary. Reaction notes.
+ */
+function controlLockedReactionFunctionality() {
+    // disabling functionality
+    $("#page-contents :input").prop("disabled", true);
+    $("#complete-reaction-button").prop('disabled', true)
+    // restoring specific functionality
+    $("#print-pdf").prop("disabled", false);
+    $("#reaction-note-button").show().prop("disabled", false);
+    $("#new-reaction-note-modal").find("*").prop("disabled", false);
+    $("#file-list").find("*").prop("disabled", false);
+    // only the creator can upload or delete files or add reaction note comments
+    if (ifCurrentUserIsNotCreator()){
+        $(".delete-file-button").prop("disabled", true);
+        $("#file-upload-div").find("*").prop("disabled", true);
+        $("#reaction-note-button").hide()
+    }
+   else {
+        $("#file-upload-div").find("*").prop("disabled", false);
+   }
 }
 
 function getFieldData() {

--- a/Webapp/sources/static/js/reaction_table/reaction_reload.js
+++ b/Webapp/sources/static/js/reaction_table/reaction_reload.js
@@ -109,9 +109,7 @@ async function reactionTableReload(){
     let js_summary_table_data = JSON.parse($("#js-summary-table-data").val());
     //  disable editing of the reaction if not owner
     if (ifCurrentUserIsNotCreator()){
-        $("#page-contents :input").prop("disabled", true);
-        // $("#print-pdf").show()
-        $("#print-pdf").prop("disabled", false);
+        controlNonCreatorFunctionality()
     }
     // load summary table if it has previously been loaded, element sustainability is used because this is autofilled upon load.
     if (js_summary_table_data["element_sustainability"] !== 'undefined'){
@@ -148,4 +146,16 @@ async function reactionTableReload(){
             autoChangeRequiredStyling2(fieldID)
         }
     }
+}
+
+/**
+ * When a user reloads a reaction they are not the creator of we disable inputs to prevent them editing the reaction
+ * We enable the options to print a PDF summary and to download/view file attachments.
+ */
+function controlNonCreatorFunctionality(){
+    $("#page-contents :input").prop("disabled", true);
+    $("#print-pdf").prop("disabled", false);
+    $("#file-list").find("*").prop("disabled", false);
+    $(".delete-file-button").prop("disabled", true);
+    $("#reaction-note-button").hide()
 }

--- a/Webapp/sources/static/js/sketcher/sketcher.js
+++ b/Webapp/sources/static/js/sketcher/sketcher.js
@@ -174,6 +174,8 @@ function sketcherLockHandler() {
     if (ifCurrentUserIsNotCreator() || $("#js-complete").val() === "complete") {
         $("#marvin-sketcher").css("pointer-events", "none");
         $("#ketcher-sketcher").css("pointer-events", "none");
+        $("#demo-button").prop('disabled', true)
+        $("#action-button-submit").prop('disabled', true)
     }
 }
 

--- a/Webapp/sources/static/js/summary_table/form_summary_table.js
+++ b/Webapp/sources/static/js/summary_table/form_summary_table.js
@@ -302,16 +302,12 @@ function showSummary() {
                 autoChangeRequiredStyling2(colorRoundedReactantMassID)
                 $('#js-summary-table').html(response.summary).show();
                 $("#print-pdf").show()
-                disableSummaryIfNotCreator()
                 autoSaveCheck()
+                // display buttons for uploading/handling file attachments and locking the reaction
                 $("#complete-reaction-div").show()
-                $("#file-upload-div").show()
+                $("#reaction-file-attachments").show()
                 if ($("#js-complete").val() === "complete"){
-                    $("#page-contents :input").prop("disabled", true);
-                    $("#print-pdf").prop("disabled", false);
-                    $("#reaction-note-button").prop("disabled", false);
-                    // enable element and all its children
-                    $("#new-reaction-note-modal").find("*").prop("disabled", false);
+                    controlLockedReactionFunctionality()
                 }
                 $("#js-load-status").val("loaded")
             }
@@ -327,14 +323,4 @@ function exportImage() {
     $image.attr("src", imgSource);
     $("#imageContainer").css("display", "block");
     sessionStorage.clear();
-}
-
-function disableSummaryIfNotCreator(){
-    // if a user who is not the creator loads the reaction, disable the inputs
-    if (ifCurrentUserIsNotCreator()){
-        $("#page-contents :input").prop("disabled", true);
-        $("#print-pdf").prop("disabled", false);
-        $("#reaction-note-button").hide()
-        // enable button to copy reaction
-    }
 }

--- a/Webapp/sources/static/js/tutorial.js
+++ b/Webapp/sources/static/js/tutorial.js
@@ -31,19 +31,19 @@ function tutorial_2(){
 function tutorial_3(){
     window.scrollTo(0, 0);
     $('#name-id').addClass('highlight');
-    $('#marvin-test').removeClass('highlight');
+    $('#sketchers-div').removeClass('highlight');
 }
 
 function tutorial_4(){
     window.scrollTo(0, document.body.scrollHeight);
     $('#name-id').removeClass('highlight');
     $('#editor-instructions').removeClass('highlight');
-    $('#marvin-test').addClass('highlight');
+    $('#sketchers-div').addClass('highlight');
 }
 
 function tutorial_5(){
     window.scrollTo(0, 0);
-    $('#marvin-test').removeClass('highlight');
+    $('#sketchers-div').removeClass('highlight');
     $('#editor-instructions').addClass('highlight');
 }
 
@@ -160,7 +160,7 @@ function tutorial_14(){
 function tutorial_15(){
     document.getElementById("print-container").style.display = "none";
     document.getElementById("complete-reaction-div").style.display = "none";
-    document.getElementById("file-upload-div").style.display = "none";
+    document.getElementById("reaction-file-attachments").style.display = "none";
     document.getElementById("print-pdf").style.display = "none";
     window.scrollTo(0, document.body.scrollHeight);
     $('#js-solvent-table-row1').removeClass('highlight');

--- a/Webapp/sources/templates/sketcher_reload.html
+++ b/Webapp/sources/templates/sketcher_reload.html
@@ -15,7 +15,6 @@
     <script>
         // disable complete reaction button once reaction is completed
         $(function () {
-            console.log($("#js-complete").val())
             if ($("#js-complete").val() === "not complete") {
                 $("#mark-complete").attr("disabled", false)
             }
@@ -104,9 +103,9 @@
     <br>
 
 
-    <div id="file-upload-div" class="mb-2" style="display:none;">
+    <div id="reaction-file-attachments" class="mb-2" style="display:none;">
         <p>Upload Experimental Data</p>
-        <div class="input-group mb-3 w-25">
+        <div id="file-upload-div" class="input-group mb-3 w-25">
             <input id="upload-files" class="form-control" type="file" multiple>
             <div class="input-group-append">
                 <button id="file-upload" class="btn btn-outline-secondary" onclick="uploadFiles()" type="button">Upload</button>
@@ -115,16 +114,15 @@
         <div id="file-list">
         {% if file_attachments %}
             {% for file in file_attachments %}
-    <!--            <button onclick="viewFile(this)" value="{{ file.uuid }}">{{ file.display_name }}</button>-->
                     <div id="file-button-group{{ loop.index }}" class="btn-group btn-group-justified mb-3" role="group" aria-label="">
                         <div class="btn-group" role="group">
-                            <button id="download-file-button{{ loop.index }}" type="button" class="btn btn-outline-primary" onclick="downloadFile(this)" value="{{ file.uuid }}"><i class="bi bi-download"></i></button>
+                            <button id="download-file-button{{ loop.index }}" type="button" class="btn btn-outline-primary download-file-button" onclick="downloadFile(this)" value="{{ file.uuid }}" title="Download"><i class="bi bi-download"></i></button>
                         </div>
                         <div class="btn-group" role="group">
-                            <button id="view-file-button{{ loop.index }}" type="button" class="btn btn-outline-dark" onclick="viewFile(this)" value="{{ file.uuid }}">{{ file.display_name }}</button>
+                            <button id="view-file-button{{ loop.index }}" type="button" class="btn btn-outline-dark view-file-button" onclick="viewFile(this)" value="{{ file.uuid }}" title="View">{{ file.display_name }}</button>
                         </div>
                         <div class="btn-group" role="group">
-                            <button id="delete-file-button{{ loop.index }}" type="button" onclick="deleteFile(this)" value="{{ file.uuid }}" class="btn btn-outline-danger"><i class="bi bi-x"></i></button>
+                            <button id="delete-file-button{{ loop.index }}" type="button" onclick="deleteFile(this)" value="{{ file.uuid }}" class="btn btn-outline-danger delete-file-button" title="Delete"><i class="bi bi-x"></i></button>
                         </div>
                     </div>
             {% endfor %}

--- a/Webapp/sources/tests/test_demo.py
+++ b/Webapp/sources/tests/test_demo.py
@@ -33,7 +33,7 @@ class MarvinInteractionTest(flask_testing.LiveServerTestCase, flask_testing.Test
     def test_marvin_loads(self):
         """This function tests that the marvin window is present in the page source"""
         pg_source = self.driver.page_source
-        self.assertIn('marvin-test', pg_source, "The marvin window must be present")
+        self.assertIn('marvin-sketcher', pg_source, "The marvin window must be present")
 
     def test_marvin_demo_function(self):
         """Here we test that compounds can be loaded into marvin_js by the example demo button by pressing the submit


### PR DESCRIPTION
# Overview

- Fixed file viewing. The backend code now supports the GET request to view the file.
- Fixed file handling permissions. Creators can change files after the reaction is locked. Non creators within the workbook can view/download but not delete the files irrespective of whether the reaction is locked.

## Azure Boards

- [AB#130121](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/130121)
