### PR TITLE
AB#130121: Non creator cannot edit summary table

### DIFF
--- a/Webapp/sources/blueprints/reaction_table/routes.py
+++ b/Webapp/sources/blueprints/reaction_table/routes.py
@@ -23,7 +23,7 @@ from sources.extensions import db  # imports the module with auxiliary functions
 
 from . import reaction_table_bp  # imports the blueprint of the reaction table route
 
-if not current_app.testing:
+if not current_app.config["DEBUG"]:
     try:
         from STOUT import translate_forward
     except:

--- a/Webapp/sources/static/js/reaction_table/reaction_reload.js
+++ b/Webapp/sources/static/js/reaction_table/reaction_reload.js
@@ -107,15 +107,15 @@ async function reactionTableReload(){
     $("#js-reaction-description").val(js_reaction_table_data["reaction_description"]);
     // get summary table
     let js_summary_table_data = JSON.parse($("#js-summary-table-data").val());
-    //  disable editing of the reaction if not owner
-    if (ifCurrentUserIsNotCreator()){
-        controlNonCreatorFunctionality()
-    }
     // load summary table if it has previously been loaded, element sustainability is used because this is autofilled upon load.
     if (js_summary_table_data["element_sustainability"] !== 'undefined'){
             setTimeout(showSummary(), 1000);
         } else{
         $loadTracker.val("loaded")
+    }
+    //  disable editing of the reaction if not owner
+    if (ifCurrentUserIsNotCreator()){
+        controlNonCreatorFunctionality()
     }
     // auxiliary reload functions that use the reaction table json
     function fillInputField(fieldID, jsonID, i){

--- a/Webapp/sources/static/js/summary_table/form_summary_table.js
+++ b/Webapp/sources/static/js/summary_table/form_summary_table.js
@@ -301,14 +301,19 @@ function showSummary() {
                 let colorRoundedReactantMassID = "#js-reactant-rounded-mass" + Number(limitingReactantTableNumber)
                 autoChangeRequiredStyling2(colorRoundedReactantMassID)
                 $('#js-summary-table').html(response.summary).show();
+                //  disable editing of the reaction if not owner
+                if (ifCurrentUserIsNotCreator()){
+                    controlNonCreatorFunctionality()
+                }
+                // disable editing if reaction is locked
+                if ($("#js-complete").val() === "complete"){
+                    controlLockedReactionFunctionality()
+                }
                 $("#print-pdf").show()
                 autoSaveCheck()
                 // display buttons for uploading/handling file attachments and locking the reaction
                 $("#complete-reaction-div").show()
                 $("#reaction-file-attachments").show()
-                if ($("#js-complete").val() === "complete"){
-                    controlLockedReactionFunctionality()
-                }
                 $("#js-load-status").val("loaded")
             }
         }


### PR DESCRIPTION
# Overview

Fixes a bug that allowed non creators to edit summary tables of unlocked reactions introduced during PR https://github.com/AI4Green/AI4Green/pull/24 


## Azure Boards

- [AB#130121](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/130121)
