### PR TITLE
AB#133164: Reload from searching all workbooks/groups

### DIFF
--- a/Webapp/sources/static/css/reaction_list.css
+++ b/Webapp/sources/static/css/reaction_list.css
@@ -1,0 +1,8 @@
+.reaction-time {
+    font-size: 11px;
+    color: darkgrey;
+}
+
+.description {
+    font-size: 12px;
+}

--- a/Webapp/sources/static/css/standard_user.css
+++ b/Webapp/sources/static/css/standard_user.css
@@ -1,8 +1,3 @@
-.reaction-time {
-    font-size: 11px;
-    color: darkgrey;
-}
-
 .line {
     height: 2px;
     border-width: 0;
@@ -15,14 +10,6 @@
     border-width: 0;
     color: black;
     background-color: black;
-}
-
-.description {
-    font-size: 12px;
-}
-
-.reaction-heading{
-    width: 400px;
 }
 
 .scrollClass {

--- a/Webapp/sources/static/js/auxiliary.js
+++ b/Webapp/sources/static/js/auxiliary.js
@@ -1,32 +1,32 @@
-window.addEventListener('load', function () {
+window.addEventListener("load", function () {
   checkCookie();
-})
+});
 
-function checkCookie(){
-    // function to check cookies preferences
-    let cookie = getCookie('cookies_preference');
-    if (cookie === 'accepted') {
-        // hide banner if user has previously accepted
-        $("#cookie-consent-banner").hide();
-    } else {
-        $("#cookie-consent-banner").show();
-        }
+function checkCookie() {
+  // function to check cookies preferences
+  let cookie = getCookie("cookies_preference");
+  if (cookie === "accepted") {
+    // hide banner if user has previously accepted
+    $("#cookie-consent-banner").hide();
+  } else {
+    $("#cookie-consent-banner").show();
+  }
 }
 
-function updateCookiePreferences(){
-    // function to update/save cookie preferences
-    document.cookie = 'cookies_preference=accepted';
-    checkCookie();
+function updateCookiePreferences() {
+  // function to update/save cookie preferences
+  document.cookie = "cookies_preference=accepted";
+  checkCookie();
 }
 
 function getCookie(cname) {
-    // retrieves cookie values from cookie object
+  // retrieves cookie values from cookie object
   let name = cname + "=";
   let decodedCookie = decodeURIComponent(document.cookie);
-  let ca = decodedCookie.split(';');
-  for(let i = 0; i <ca.length; i++) {
+  let ca = decodedCookie.split(";");
+  for (let i = 0; i < ca.length; i++) {
     let c = ca[i];
-    while (c.charAt(0) == ' ') {
+    while (c.charAt(0) == " ") {
       c = c.substring(1);
     }
     if (c.indexOf(name) == 0) {
@@ -38,10 +38,21 @@ function getCookie(cname) {
 
 /**
  *  Uses JQuery to get the value from an element and escape special characters to prevent XSS vulnerabilities
- * @param jquerySelector- The JQuery Selector used to get the value
+ * @param jquerySelector {jQuery | HTMLElement | String}- The JQuery Selector used to get the value
  * @returns {String} - The value of HTML element with special characters escaped
  */
-function getVal (jquerySelector){
-    const unescapedInput = $(jquerySelector).val();
-    return $("<div>").text(unescapedInput).html();
+function getVal(jquerySelector) {
+  const unescapedInput = $(jquerySelector).val();
+  return $("<div>").text(unescapedInput).html();
+}
+
+/**
+ * Uses JQuery to get the value of a data-* attribute from a HTML element and escapes special characters
+ * @param jquerySelector {jQuery | HTMLElement | String} - The jQuery Selector used to get the value
+ * @param dataAttribute {String} - The specific data attribute e.g., to access data-workbook arg should be 'workbook'
+ * @returns {String} - The data-* value of the HTML element with special characters escaped
+ */
+function getData(jquerySelector, dataAttribute) {
+  const unescapedInput = $(jquerySelector).data(dataAttribute);
+  return $("<div>").text(unescapedInput).html();
 }

--- a/Webapp/sources/static/js/reaction_list.js
+++ b/Webapp/sources/static/js/reaction_list.js
@@ -2,40 +2,38 @@
  * Gets reactions for specific workbook/workgroup via an AJAX request and adds to the reaction list HTML
  * @param sortCriteria {string} - the sort criteria will be either a-z or time
  */
-function getReactions(sortCriteria){
-    let workbook = getVal("#active-workbook")
-    console.log(workbook)
-    if (workbook === "No Workbooks to Show" || workbook === "None"){
-        document.getElementById("export-div").style.display = "none";
-        document.getElementById("new-reaction").style.display = "none";
-    }
-    else {
-        document.getElementById("reaction-content").style.display = "block";
-        document.getElementById("reaction-column").style.display = "block";
-        document.getElementById("no-reactions").style.display = "none";
-        let workgroup = getVal("#active-workgroup")
-        let workbook = getVal("#active-workbook")
-        $.ajax({
-            url: '/get_reactions',
-            type: 'post',
-            dataType: 'json',
-            data: {
-                workbook: workbook,
-                workgroup: workgroup,
-                sortCriteria: sortCriteria
-            },
-            success: function (data) {
-                $('#reaction-details').html(data.reactionDetails).show(); // sends data to the reaction list
-            }
-        })
-    }
+function getReactions(sortCriteria) {
+  let workbook = getVal("#active-workbook");
+  if (workbook === "No Workbooks to Show" || workbook === "None") {
+    document.getElementById("export-div").style.display = "none";
+    document.getElementById("new-reaction").style.display = "none";
+  } else {
+    document.getElementById("reaction-content").style.display = "block";
+    document.getElementById("reaction-column").style.display = "block";
+    document.getElementById("no-reactions").style.display = "none";
+    let workgroup = getVal("#active-workgroup");
+    let workbook = getVal("#active-workbook");
+    $.ajax({
+      url: "/get_reactions",
+      type: "post",
+      dataType: "json",
+      data: {
+        workbook: workbook,
+        workgroup: workgroup,
+        sortCriteria: sortCriteria,
+      },
+      success: function (data) {
+        $("#reaction-details").html(data.reactionDetails).show(); // sends data to the reaction list
+      },
+    });
+  }
 }
 
 /**
  * Calls the getReactions() func if the workbook dropdown is changed, which updates the reaction list.
  */
-function updateSelectedWorkbook () {
-    getReactions("AZ");
+function updateSelectedWorkbook() {
+  getReactions("AZ");
 }
 
 /**
@@ -43,13 +41,13 @@ function updateSelectedWorkbook () {
  * and assigns the reaction id corresponding to the active workbook
  */
 function newReactionModalWindow() {
-    let reactionIDs = getVal("#workbook_corresponding_next_reaction_ids")
-    let reactionIDsDic = JSON.parse(reactionIDs)
-    let workbook = getVal("#active-workbook")
-    let activeReactionID = reactionIDsDic[workbook]
-    $("#new-reaction-id").val(activeReactionID)
-    $("#new-reaction-name").val('')
-    $("#error-warning-new-reaction").html('')
+  let reactionIDs = getVal("#workbook_corresponding_next_reaction_ids");
+  let reactionIDsDic = JSON.parse(reactionIDs);
+  let workbook = getVal("#active-workbook");
+  let activeReactionID = reactionIDsDic[workbook];
+  $("#new-reaction-id").val(activeReactionID);
+  $("#new-reaction-name").val("");
+  $("#error-warning-new-reaction").html("");
 }
 
 /**
@@ -57,31 +55,30 @@ function newReactionModalWindow() {
  * Upon successful validation creates a new reaction and redirects browser to the page for the new reaction
  */
 function newReactionCreate() {
-    // creates new reaction if name and ID pass validation in the backend routes.
-    let workgroup = getVal("#active-workgroup")
-    let workbook = getVal("#active-workbook")
-    let reactionName = getVal("#new-reaction-name")
-    let reactionID = getVal("#new-reaction-id")
+  // creates new reaction if name and ID pass validation in the backend routes.
+  let workgroup = getVal("#active-workgroup");
+  let workbook = getVal("#active-workbook");
+  let reactionName = getVal("#new-reaction-name");
+  let reactionID = getVal("#new-reaction-id");
 
-    $.ajax({
-        url: "/new_reaction",
-        type: 'post',
-        datatype: 'json',
-        data: {
-            reactionName: reactionName,
-            reactionID: reactionID,
-            workgroup: workgroup,
-            workbook: workbook
-        },
-        success: function (response) {
-            if (response.feedback === 'New reaction made') {
-                window.location.href = `/sketcher/${workgroup}/${workbook}/${reactionID}/no`;
-            }
-            else {
-                $("#error-warning-new-reaction").html(response.feedback);
-            }
-        }
-    })
+  $.ajax({
+    url: "/new_reaction",
+    type: "post",
+    datatype: "json",
+    data: {
+      reactionName: reactionName,
+      reactionID: reactionID,
+      workgroup: workgroup,
+      workbook: workbook,
+    },
+    success: function (response) {
+      if (response.feedback === "New reaction made") {
+        window.location.href = `/sketcher/${workgroup}/${workbook}/${reactionID}/no`;
+      } else {
+        $("#error-warning-new-reaction").html(response.feedback);
+      }
+    },
+  });
 }
 
 /**
@@ -89,30 +86,34 @@ function newReactionCreate() {
  * @param reaction {HTMLElement}
  */
 function deleteReaction(reaction) {
-    const completeConfirm = window.confirm("Are you sure you want to permanently delete this reaction?");
-    if (completeConfirm === false) {
-        return;
-    }
-    let workgroup = getVal("#active-workgroup")
-    let workbook = getVal("#active-workbook")
-    // id of reaction element is the reaction_id of the reaction
-    location.href = `/delete_reaction/${reaction.id}/${workgroup}/${workbook}`;
+  const completeConfirm = window.confirm(
+    "Are you sure you want to permanently delete this reaction?",
+  );
+  if (completeConfirm === false) {
+    return;
+  }
+  let workbook = getData(reaction, "workbook");
+  let workgroup = getData(reaction, "workgroup");
+  // id of reaction element is the reaction_id of the reaction
+  location.href = `/delete_reaction/${reaction.id}/${workgroup}/${workbook}`;
 }
 
 /**
  * Redirects the browser to the page of the reloaded reaction via the main/sketcher routes
  * @param reaction {HTMLElement}
  */
-function redirectToReloadReaction(reaction){
-    let workgroup = getVal("#active-workgroup")
-    let workbook = getVal("#active-workbook")
-    // search results open in new tab, otherwise reloaded reactions open in current tab
-    if (window.location.pathname.split('/')[1] === 'search'){
-        window.open(`/sketcher/${workgroup}/${workbook}/${reaction.id}/no`, '_blank')
-    }
-    else {
-        window.location.href = `/sketcher/${workgroup}/${workbook}/${reaction.id}/no`;
-    }
+function redirectToReloadReaction(reaction) {
+  let workbook = getData(reaction, "workbook");
+  let workgroup = getData(reaction, "workgroup");
+  // search results open in new tab, otherwise reloaded reactions open in current tab
+  if (window.location.pathname.split("/")[1] === "search") {
+    window.open(
+      `/sketcher/${workgroup}/${workbook}/${reaction.id}/no`,
+      "_blank",
+    );
+  } else {
+    window.location.href = `/sketcher/${workgroup}/${workbook}/${reaction.id}/no`;
+  }
 }
 
 /**
@@ -123,68 +124,81 @@ function redirectToReloadReaction(reaction){
  * @param size {string} - the size of the reaction scheme image
  * @return {Promise<Array>} - array of reaction scheme images formatted as an svg
  */
-function getSchemata(sortCriteria, workbook, workgroup, size){
-    return new Promise(function(resolve, reject){
-        // post to get_schemata and get the schemes for reaction images
-        $.ajax({
-            method: "POST",
-            url: "/get_schemata",
-            dataType: 'json',
-            data: {
-                sortCriteria: sortCriteria,
-                workgroup: workgroup,
-                workbook: workbook,
-                size: size
-            },
-            success: function (data) {
-                resolve(data.schemes)
-            },
-            error: function () {
-                reject("error accessing /get_schemata")
-            }
-        });
+function getSchemata(sortCriteria, workbook, workgroup, size) {
+  return new Promise(function (resolve, reject) {
+    // post to get_schemata and get the schemes for reaction images
+    $.ajax({
+      method: "POST",
+      url: "/get_schemata",
+      dataType: "json",
+      data: {
+        sortCriteria: sortCriteria,
+        workgroup: workgroup,
+        workbook: workbook,
+        size: size,
+      },
+      success: function (data) {
+        resolve(data.schemes);
+      },
+      error: function () {
+        reject("error accessing /get_schemata");
+      },
     });
+  });
 }
 
 /**
  * Sorts reactions alphabetically, reordering the cards in the list
  */
-function sortReactionsAlphabetically(){
-    let reactionCards = $(".reaction-card")
-    // sorts by reaction name
-    reactionCards.sort((a, b) => a.querySelector(".reaction-name").firstChild.innerHTML.toLowerCase().
-    localeCompare(b.querySelector(".reaction-name").firstChild.innerHTML.toLowerCase()))
-    $("#reaction-list").empty()
-    $("#reaction-list").append(reactionCards)
+function sortReactionsAlphabetically() {
+  let reactionCards = $(".reaction-card");
+  // sorts by reaction name
+  reactionCards.sort((a, b) =>
+    a
+      .querySelector(".reaction-name")
+      .firstChild.innerHTML.toLowerCase()
+      .localeCompare(
+        b.querySelector(".reaction-name").firstChild.innerHTML.toLowerCase(),
+      ),
+  );
+  $("#reaction-list").empty();
+  $("#reaction-list").append(reactionCards);
 }
 
 /**
  * Sorts reactions in date order, reordering the cards in the list
  */
-function sortReactionsByTime(){
-    let reactionCards = $(".reaction-card")
-    reactionCards.sort(function(a, b) {return new Date(b.querySelector(".reaction-time").innerHTML) - new Date(a.querySelector(".reaction-time").innerHTML)})
-    $("#reaction-list").empty()
-    $("#reaction-list").append(reactionCards)
+function sortReactionsByTime() {
+  let reactionCards = $(".reaction-card");
+  reactionCards.sort(function (a, b) {
+    return (
+      new Date(b.querySelector(".reaction-time").innerHTML) -
+      new Date(a.querySelector(".reaction-time").innerHTML)
+    );
+  });
+  $("#reaction-list").empty();
+  $("#reaction-list").append(reactionCards);
 }
 
 /**
  * Calls the export_data_pdf routes to open a page where all reactions schemes are in the PDF for the workbook
  */
-function getpdf(){
-    let workgroup = getVal("#active-workgroup")
-    let workbook = getVal("#active-workbook")
-    let sortCriteria = getVal("#js-sort-crit")
-    window.open(`/export_data_pdf/${workgroup}/${workbook}/${sortCriteria}`, '_blank').focus();
+function getpdf() {
+  let workgroup = getVal("#active-workgroup");
+  let workbook = getVal("#active-workbook");
+  let sortCriteria = getVal("#js-sort-crit");
+  window
+    .open(`/export_data_pdf/${workgroup}/${workbook}/${sortCriteria}`, "_blank")
+    .focus();
 }
 
 /**
  * Calls the export_data_csv routes to prompt download of a csv with all reaction data for the workbook
  */
-function getcsv(){
-    let workgroup = getVal("#active-workgroup")
-    let workbook = getVal("#active-workbook")
-    window.location = `/export_data_csv/${workgroup}/${workbook}`;
+function getcsv() {
+  let workgroup = getVal("#active-workgroup");
+  let workbook = getVal("#active-workbook");
+  window.location = `/export_data_csv/${workgroup}/${workbook}`;
 }
 
 /**
@@ -192,12 +206,12 @@ function getcsv(){
  * @return {Promise<void>}
  */
 async function showSavedReactionsSchemes() {
-    let sortCriteria = getVal("#js-sort-crit")
-    let workgroup = getVal("#active-workgroup")
-    let workbook = getVal("#active-workbook")
-    let schemes = await getSchemata(sortCriteria, workbook, workgroup, "small")
-    for (const [idx, scheme] of schemes.entries()){
-        let idx1 = idx + 1
-        $(`#image${idx1}`).append($('<div>').html(scheme))
-    }
+  let sortCriteria = getVal("#js-sort-crit");
+  let workgroup = getVal("#active-workgroup");
+  let workbook = getVal("#active-workbook");
+  let schemes = await getSchemata(sortCriteria, workbook, workgroup, "small");
+  for (const [idx, scheme] of schemes.entries()) {
+    let idx1 = idx + 1;
+    $(`#image${idx1}`).append($("<div>").html(scheme));
+  }
 }

--- a/Webapp/sources/templates/_saved_reactions.html
+++ b/Webapp/sources/templates/_saved_reactions.html
@@ -1,5 +1,6 @@
 <head>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/reaction_list.css') }}">
 <script>
     $(function() {
         if (window.location.pathname.split("/")[1] !== 'search') {
@@ -28,9 +29,15 @@
             <div id="image{{ loop.index }}"></div>
             <div class="reaction-time">Created: {{ reaction.time_of_creation[:-7] }}</div>
             <div class="reaction-time">Edited: {{ reaction.time_of_update[:-7] }}</div>
-            <button onclick="redirectToReloadReaction(this)" id="{{ reaction.reaction_id }}" class="btn btn-success reload-btn">Reload</button>
+            <button
+                    id="{{ reaction.reaction_id }}" onclick="redirectToReloadReaction(this)" class="btn btn-success reload-btn"
+                    data-workgroup="{{ reaction.workgroup }}" data-workbook="{{ reaction.workbook }}">Reload
+            </button>
             {% if reaction.creator_email == current_user.email %}
-                <button onclick="deleteReaction(this)" id="{{ reaction.reaction_id }}" name="delete-reaction" class="btn btn-danger">Delete</button>
+                <button
+                        id="{{ reaction.reaction_id }}" onclick="deleteReaction(this)" name="delete-reaction" class="btn btn-danger"
+                        data-workgroup="{{ reaction.workgroup }}" data-workbook="{{ reaction.workbook }}">Delete
+                </button>
             {% endif %}
             {% if reaction.completion_status == "complete" %}
                 <i class="fa fa-lock" style="font-size:20px; color:darkgrey;"></i><b style="font-size:12px; color:darkgrey;">  Reaction Locked</b>

--- a/Webapp/sources/templates/base.html
+++ b/Webapp/sources/templates/base.html
@@ -21,7 +21,7 @@
     <script type="text/javascript" src="{{ url_for('static', filename='js/auxiliary.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/sketcher/sketcher_utils.js') }}"></script>
 <!--    Internal CSS styling-->
-    <link id="sketcher-button" rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/pagestyle.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/standard_user.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/pagestyle.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/hazard_colours.css') }}">
 </head>


### PR DESCRIPTION
# Overview

This PR fixes a bug that prevented the reloading/deleting of reactions from the search page. Also has minor JS and CSS changes.

- CSS change to use same reaction list styling in search page as workgroup page
- CSS change to remove unused classes
- New JS function extract data-* attributes from HTML elements
- Prettify used on reaction_list.js to reformat

## Azure Boards

- AB#`133164`
