### PR TITLE
AB#133679: Enable workgroup deletion after workbook has been made

### DIFF
--- a/Webapp/sources/models/workbook.py
+++ b/Webapp/sources/models/workbook.py
@@ -1,4 +1,5 @@
 from sources.extensions import db
+
 from .base import Model
 
 
@@ -14,10 +15,7 @@ class WorkBook(Model):
     __tablename__ = "WorkBook"
     __table_args__ = (db.UniqueConstraint("name", "group"),)
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True
-    )
+    id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text, nullable=False)
     abbreviation = db.Column(db.Text, nullable=False)
     group = db.Column(
@@ -26,5 +24,9 @@ class WorkBook(Model):
     time_of_creation = db.Column(db.DateTime)
 
     WorkGroup = db.relationship("WorkGroup", backref="WorkBook")
-    reactions = db.relationship("Reaction", backref="WorkBook")
+    reactions = db.relationship(
+        "Reaction",
+        backref="WorkBook",
+        cascade="all, delete",
+    )
     users = db.relationship("Person", secondary="Person_WorkBook")

--- a/Webapp/sources/models/workgroup.py
+++ b/Webapp/sources/models/workgroup.py
@@ -1,4 +1,5 @@
 from sources.extensions import db
+
 from .base import Model
 
 
@@ -14,10 +15,7 @@ class WorkGroup(Model):
     __tablename__ = "WorkGroup"
     __table_args__ = (db.UniqueConstraint("name", "institution"),)
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True
-    )
+    id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text, nullable=False)
     institution = db.Column(
         db.ForeignKey("Institution.id", ondelete="CASCADE"), nullable=False, index=True
@@ -26,8 +24,8 @@ class WorkGroup(Model):
     time_of_creation = db.Column(db.DateTime)
 
     WorkGroup_Status_Request = db.relationship("WGStatusRequest")
-    workbooks = db.relationship("WorkBook")
-    request = db.relationship("WorkGroupRequest")
+    workbooks = db.relationship("WorkBook", cascade="all, delete")
+    request = db.relationship("WorkGroupRequest", cascade="all, delete")
     principal_investigator = db.relationship(
         "Person",
         secondary="Person_WorkGroup",

--- a/Webapp/sources/models/workgroup_request.py
+++ b/Webapp/sources/models/workgroup_request.py
@@ -1,4 +1,5 @@
 from sources.extensions import db
+
 from .base import Model
 
 
@@ -14,10 +15,7 @@ class WorkGroupRequest(Model):
     __tablename__ = "WorkGroup_request"
     __table_args__ = (db.UniqueConstraint("name", "institution"),)
 
-    id = db.Column(
-        db.Integer,
-        primary_key=True
-    )
+    id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text, nullable=False)
     principal_investigator = db.Column(
         db.ForeignKey("Person.id", ondelete="CASCADE"), nullable=False, index=True
@@ -36,4 +34,6 @@ class WorkGroupRequest(Model):
         "Person", foreign_keys=[principal_investigator], backref="WorkGroupRequest"
     )
     Institution = db.relationship("Institution", backref="WorkGroupRequest")
-    WorkGroup = db.relationship("WorkGroup", backref="WorkGroupRequest")
+    WorkGroup = db.relationship(
+        "WorkGroup", backref="WorkGroupRequest", cascade="all, delete"
+    )


### PR DESCRIPTION
# Overview

Enables deletion of workgroups that contain workbooks/reactions. Fixed by editing the cascade delete in models files.

## Azure Boards

- [AB#133679](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/133679)
