### PR TITLE
AB#133680: Email configuration for local use changed from bool to string

### DIFF
--- a/Webapp/sources/config.py
+++ b/Webapp/sources/config.py
@@ -34,7 +34,7 @@ class BaseConfig(object):  # class to store configuration variables
     MAIL_PASSWORD = os.getenv("MAIL_PASSWORD", "None")
     MAIL_USE_TLS = os.getenv("MAIL_USE_TLS", False)
     MAIL_USE_SSL = os.getenv("MAIL_USE_SSL", True)
-    MAIL_USE_LOCAL = os.getenv("MAIL_USE_LOCAL", True)
+    MAIL_USE_LOCAL = os.getenv("MAIL_USE_LOCAL", "local")
     MAIL_ADMIN_SENDER = os.getenv("MAIL_ADMIN_SENDER", "admin@ai4green.app")
     MAIL_SAVE_DIR = os.getenv("MAIL_SAVE_DIR", "temp")
 

--- a/Webapp/sources/email_sender/email_sender.py
+++ b/Webapp/sources/email_sender/email_sender.py
@@ -48,7 +48,7 @@ class EmailSender:
         """
         Send an email based on the parameters.
 
-        If config setting MAIL_USE_LOCAL is true, the email is saved locally instead.
+        If config setting MAIL_USE_LOCAL is 'local', the email is saved locally instead.
 
         Args:
             subject: Subject of the email.
@@ -57,7 +57,7 @@ class EmailSender:
             text_body: Text body of the email.
             html_body: HTML body of the email.
         """
-        if current_app.config["MAIL_USE_LOCAL"]:
+        if current_app.config["MAIL_USE_LOCAL"] == "local":
             self._save_local(subject, sender, recipients, text_body, html_body)
         else:
             msg = Message(subject, sender=sender, recipients=recipients)

--- a/Webapp/tests/services/test_email_sender.py
+++ b/Webapp/tests/services/test_email_sender.py
@@ -35,10 +35,10 @@ def test_send_email_sending(app):
 @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Local temp files don't work in CI")
 def test_send_email_local_save(app):
     """
-    Test saving an email locally when MAIL_USE_LOCAL is set to True.
+    Test saving an email locally when MAIL_USE_LOCAL is set to 'local'.
 
     This test ensures that the 'send_email' function correctly saves the email locally when the 'MAIL_USE_LOCAL'
-    configuration is set to True. The email content should be stored in a file on the local storage.
+    configuration is set to 'local'. The email content should be stored in a file on the local storage.
 
     Args:
         client: Flask test client.


### PR DESCRIPTION
# Overview

The string environmental variable can be read correctly without any additional code allowing the email configuration to use local or a server by setting the app configuration

## Azure Boards

- [AB#133680](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/133680)
