### PR TITLE
AB#133680: Email links use HTTPS

### DIFF
--- a/Webapp/sources/services/email.py
+++ b/Webapp/sources/services/email.py
@@ -33,15 +33,16 @@ def send_password_reset(user: models.User) -> None:
         user: User to send to.
     """
     token = get_reset_password_token(user)
+    protocol = get_protocol_type()
     mail.send_email(
         "AI4Chem Reset Your Password",
         sender=current_app.config["MAIL_ADMIN_SENDER"],
         recipients=[user.email],
         text_body=render_template(
-            "email/reset_password_text.txt", user=user, token=token
+            "email/reset_password_text.txt", user=user, token=token, protocol=protocol
         ),
         html_body=render_template(
-            "email/reset_password_text.html", user=user, token=token
+            "email/reset_password_text.html", user=user, token=token, protocol=protocol
         ),
     )
 
@@ -51,15 +52,20 @@ def send_notification(person: models.Person):
     Send notifications email to a user.
 
     Args:
-        Person: Person to send to.
+        person: Person to send to.
 
     """
+    protocol = get_protocol_type()
     mail.send_email(
         "You have a new AI4Green notification",
         sender=current_app.config["MAIL_ADMIN_SENDER"],
         recipients=[person.user.email],
-        text_body=render_template("email/notification_text.txt", user=person.user),
-        html_body=render_template("email/notification_text.html", user=person.user),
+        text_body=render_template(
+            "email/notification_text.txt", user=person.user, protocol=protocol
+        ),
+        html_body=render_template(
+            "email/notification_text.html", user=person.user, protocol=protocol
+        ),
     )
 
 
@@ -111,3 +117,14 @@ def verify_reset_password_token(token: str) -> models.User:
     except Exception:
         return
     return models.User.query.get(user_id)
+
+
+def get_protocol_type() -> str:
+    """
+    The desired protocol type depends on the current deployment environment.
+    http for local and https if the app is deployed on a remote server
+
+    Returns:
+          the active protocol type
+    """
+    return "http" if current_app.config["MAIL_USE_LOCAL"] == "local" else "https"

--- a/Webapp/sources/templates/email/notification_text.html
+++ b/Webapp/sources/templates/email/notification_text.html
@@ -1,11 +1,11 @@
 <p>Dear {{ user.username }},</p>
 <p>
     You have a new AI4Green notification. To view this notification
-    <a href="{{ url_for('notifications.notifications', _external=True) }}">
+    <a href="{{ url_for('notifications.notifications', _external=True, _scheme='protocol') }}">
         click here.</a>
 </p>
 <p>Alternatively, you can paste the following link in your browser's address bar:</p>
-<p>{{ url_for('notifications.notifications', _external=True) }} </p>
+<p>{{ url_for('notifications.notifications', _external=True, _scheme='protocol') }} </p>
 <p>You are receiving this message because you are signed up to AI4Green with this email address.</p>
 <p>Sincerely,</p>
 <p>The AI4Green Team</p>

--- a/Webapp/sources/templates/email/notification_text.txt
+++ b/Webapp/sources/templates/email/notification_text.txt
@@ -1,10 +1,10 @@
 Dear {{ user.username }},
 
-You have a new AI4Green notification. To view this notification <a href="{{ url_for('notifications.notifications', _external=True) }}">click here.</a>
+You have a new AI4Green notification. To view this notification <a href="{{ url_for('notifications.notifications', _external=True, _scheme='protocol') }}">click here.</a>
 
 Alternatively, you can paste the following link in your browser's address bar:
 
-{{ url_for('notifications.notifications', _external=True) }}
+{{ url_for('notifications.notifications', _external=True, _scheme='protocol') }}
 
 You are receiving this message because you are signed up to AI4Green with this email address.
 

--- a/Webapp/sources/templates/email/reset_password_text.html
+++ b/Webapp/sources/templates/email/reset_password_text.html
@@ -1,11 +1,11 @@
 <p>Dear {{ user.username }},</p>
 <p>
     To reset/change your password
-    <a href="{{ url_for('reset_password.reset_password', token=token, _external=True) }}">
+    <a href="{{ url_for('reset_password.reset_password', token=token, _external=True, _scheme='protocol') }}">
         click here.</a>
 </p>
 <p>Alternatively, you can paste the following link in your browser's address bar:</p>
-<p>{{ url_for('reset_password.reset_password', token=token, _external=True) }}</p>
+<p>{{ url_for('reset_password.reset_password', token=token, _external=True, _scheme='protocol') }}</p>
 <p>If you have not requested a password reset simply ignore this message.</p>
 <p>Sincerely,</p>
 <p>The AI4Green Team</p>

--- a/Webapp/sources/templates/email/reset_password_text.txt
+++ b/Webapp/sources/templates/email/reset_password_text.txt
@@ -2,7 +2,7 @@ Dear {{ user.username }},
 
 To reset/change your password click on the following link:
 
-{{ url_for('reset_password.reset_password', token=token, _external=True) }}
+{{ url_for('reset_password.reset_password', token=token, _external=True, _scheme='protocol') }}
 
 If you have not requested a password reset simply ignore this message.
 


### PR DESCRIPTION
# Overview

Email links now use HTTPS when the app is actually sending emails or HTTP if the app is only running locally.
This is aimed to stop emails being filtered or sent to junk

## Azure Boards

- [AB#133680](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/133680)
