### PR TITLE
AB#179143: Reaction constructor fixes

### DIFF
--- a/Webapp/sources/static/js/reaction_table/file_handling.js
+++ b/Webapp/sources/static/js/reaction_table/file_handling.js
@@ -181,11 +181,6 @@ function showFileAttachmentButtons(uploadedFiles) {
 }
 
 function validateFile(file) {
-  let fileExtensionValidation = validateFileExtension(file);
-  if (fileExtensionValidation === "failed") {
-    alert("Files must be of type 'pdf', 'jpeg', or 'png'");
-    return false;
-  }
   let fileSizeValidation = validateFileSize(file);
   if (fileSizeValidation === "failed") {
     alert("Files must be  below 1 mb");
@@ -197,15 +192,6 @@ function validateFile(file) {
 function validateFileSize(file) {
   // if larger than 1 mb
   if (file.size > 1000000) {
-    return "failed";
-  }
-  return "success";
-}
-
-function validateFileExtension(file) {
-  let acceptedFileExtensions = ["pdf", "jpeg", "jpg", "png"];
-  let fileExtension = file.name.split(".").slice(-1)[0];
-  if (!acceptedFileExtensions.includes(fileExtension)) {
     return "failed";
   }
   return "success";

--- a/Webapp/sources/static/js/sketcher/sketcher.js
+++ b/Webapp/sources/static/js/sketcher/sketcher.js
@@ -216,8 +216,16 @@ async function reloadSketcher() {
       marvin.importStructure("cxsmiles", reloadedReaction);
       await sleep(500);
     } else if (selectedSketcher === "ketcher-select") {
-      let ketcher = getKetcher();
-      ketcher.setMolecule(reloadedReaction);
+      // wait for ketcher to load and if it has loaded then reload the scheme
+      for (let i = 0; i < 5; i++) {
+        let ketcher = getKetcher();
+        if (ketcher !== undefined) {
+          ketcher.setMolecule(reloadedReaction);
+          break;
+        } else {
+          await sleep(250);
+        }
+      }
       // sleep used to allow ketcher to load smiles before proceeding
       await sleep(2000);
     }


### PR DESCRIPTION
# Overview

- Removes file extension validation from frontend to use only backend
- Reload function now waits for ketcher to load before trying to add SMILES

## Azure Boards

- [AB#179143](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/179143)
