### PR TITLE
AB#199406: Feature/add OIDC

### DIFF
--- a/Webapp/sources/__init__.py
+++ b/Webapp/sources/__init__.py
@@ -10,7 +10,7 @@ from apiflask import APIFlask
 from flask import Flask
 from sources import config, models
 from sources.auxiliary import get_notification_number, get_workgroups
-from sources.extensions import db, login, ma, mail, migrate
+from sources.extensions import db, login, ma, mail, migrate, oidc
 
 
 def create_app(c: str = "dev") -> Flask:
@@ -86,6 +86,8 @@ def register_extensions(app: Flask) -> None:
 
     login.init_app(app)
     login.login_view = "auth.login"
+
+    oidc.init_app(app)
 
     @login.user_loader
     def load_user(user_id: int):

--- a/Webapp/sources/blueprints/auth/routes.py
+++ b/Webapp/sources/blueprints/auth/routes.py
@@ -155,6 +155,8 @@ def oidc_callback() -> Response:
             password_data=user_info["sub"],
             person=person,
         )
+        # send verification email
+        services.email.send_email_verification(person.user)
 
     # OIDC and regular login are different. Use `login_user` to hook into
     # the regular login/out system

--- a/Webapp/sources/blueprints/auth/routes.py
+++ b/Webapp/sources/blueprints/auth/routes.py
@@ -3,6 +3,7 @@ This module contains user authentication functions:
 login, logout, and register
 """
 
+import uuid
 from flask import (
     Response,
     flash,
@@ -151,12 +152,14 @@ def oidc_callback() -> Response:
             username=user_info["name"],
             email=user_info["email"],
             fullname=user_info["name"],
-            # user sub is a UUID
-            password_data=user_info["sub"],
+            # generate UUID for mandatory field
+            password_data=str(uuid.uuid4()),
             person=person,
         )
         # send verification email
         services.email.send_email_verification(person.user)
+        # get the new user
+        user = services.user.from_email(user_email=user_info["email"])
 
     # OIDC and regular login are different. Use `login_user` to hook into
     # the regular login/out system

--- a/Webapp/sources/blueprints/auth/routes.py
+++ b/Webapp/sources/blueprints/auth/routes.py
@@ -6,7 +6,7 @@ login, logout, and register
 from flask import Response, flash, redirect, render_template, request, url_for
 from flask_login import current_user, logout_user
 from sources import auxiliary, models, services
-from sources.extensions import db
+from sources.extensions import db, oidc
 
 from . import auth_bp
 from .forms import LoginForm, RegistrationForm
@@ -102,3 +102,13 @@ def hazard_disclaimer() -> Response:
         flask.Response The hazard disclaimer page
     """
     return render_template("general/hazards_disclaimer.html")
+
+
+@auth_bp.route("/oidc-login")
+def oidc_login() -> Response:
+    """Redirect the user to the OpenID Connect login page.
+
+    Returns:
+        Response: redirect to the OIDC login page.
+    """
+    return oidc.redirect_to_auth_server()

--- a/Webapp/sources/blueprints/auth/routes.py
+++ b/Webapp/sources/blueprints/auth/routes.py
@@ -141,7 +141,7 @@ def oidc_callback() -> Response:
         Response: Redirect the to main screen when the user logs in.
     """
     # Attempt to find a user in the AI4Green database with an email from the OIDC provider
-    user_info = oidc.user_getinfo(["sub", "email", "name"])
+    user_info = oidc.user_getinfo(["email", "name"])
     user = services.user.from_email(user_email=user_info["email"])
 
     # If the user doesn't exist, add them.

--- a/Webapp/sources/blueprints/auth/routes.py
+++ b/Webapp/sources/blueprints/auth/routes.py
@@ -104,7 +104,7 @@ def hazard_disclaimer() -> Response:
     return render_template("general/hazards_disclaimer.html")
 
 
-@auth_bp.route("/oidc-login")
+@auth_bp.route("/oidc_login")
 def oidc_login() -> Response:
     """Redirect the user to the OpenID Connect login page.
 

--- a/Webapp/sources/config.py
+++ b/Webapp/sources/config.py
@@ -6,7 +6,10 @@ This is a configuration module for the app
 import os
 
 from dotenv import load_dotenv
-from sources.services.controlled_substances import uk_arms_embargoes, controlled_substance_inchi
+from sources.services.controlled_substances import (
+    uk_arms_embargoes,
+    controlled_substance_inchi,
+)
 
 load_dotenv()
 
@@ -18,7 +21,7 @@ class BaseConfig(object):  # class to store configuration variables
     key as a cryptographic key to generate signatures or tokens.
     The Flask-WTF extension uses it to protect web forms against
     Cross-Site Request Forgery."""
-    SERVER_NAME = os.getenv("SERVER_NAME", "127.0.0.1:80")
+    SERVER_NAME = os.getenv("SERVER_NAME", "127.0.0.1:5000")
     SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
     WTF_CSRF_ENABLED = False
     LIVESERVER_TIMEOUT = 10
@@ -128,13 +131,28 @@ class BaseConfig(object):  # class to store configuration variables
 
     CONDITIONS_API_URL = os.getenv("CONDITIONS_API_URL", "http://127.0.0.1:9901")
 
-    IPINFO_API_KEY = os.getenv("IPINFO_API_KEY", "") # change to your own
+    IPINFO_API_KEY = os.getenv("IPINFO_API_KEY", "")  # change to your own
 
-    EXPORT_CONTROL_EMAIL_ADDRESS = os.getenv("EXPORT_CONTROL_EMAIL_ADDRESS", "") # who to alert for controlled substance usage
+    EXPORT_CONTROL_EMAIL_ADDRESS = os.getenv(
+        "EXPORT_CONTROL_EMAIL_ADDRESS", ""
+    )  # who to alert for controlled substance usage
 
     CONTROLLED_SUBSTANCES = controlled_substance_inchi()
 
     EMBARGOED_COUNTRIES = uk_arms_embargoes()
+
+    OIDC_CLIENT_SECRETS = {
+        "web": {
+            "client_id": os.getenv("OIDC_CLIENT_ID", ""),
+            "client_secret": os.getenv("OIDC_CLIENT_SECRET", ""),
+            "auth_uri": os.getenv("OIDC_AUTH_URI", ""),
+            "token_uri": os.getenv("OIDC_TOKEN_URI", ""),
+            "userinfo_uri": os.getenv("OIDC_USERINFO_URI", ""),
+            "issuer": os.getenv("OIDC_ISSUER", ""),
+            # pass redirect uris as a comma-separated string (uri1,uri2,...)
+            "redirect_uris": str.split(os.getenv("OIDC_REDIRECT_URIS", ""), ","),
+        }
+    }
 
 
 class TestConfig(BaseConfig):

--- a/Webapp/sources/config.py
+++ b/Webapp/sources/config.py
@@ -21,7 +21,7 @@ class BaseConfig(object):  # class to store configuration variables
     key as a cryptographic key to generate signatures or tokens.
     The Flask-WTF extension uses it to protect web forms against
     Cross-Site Request Forgery."""
-    SERVER_NAME = os.getenv("SERVER_NAME", "127.0.0.1:5000")
+    SERVER_NAME = os.getenv("SERVER_NAME", "127.0.0.1:80")
     SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
     WTF_CSRF_ENABLED = False
     LIVESERVER_TIMEOUT = 10

--- a/Webapp/sources/extensions.py
+++ b/Webapp/sources/extensions.py
@@ -6,6 +6,7 @@ Extensions module.
 from flask_login import LoginManager
 from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
+from flask_oidc import OpenIDConnect
 from flask_sqlalchemy import SQLAlchemy
 from sources.email_sender import EmailSender
 
@@ -14,3 +15,4 @@ mail = EmailSender()
 ma = Marshmallow()
 db = SQLAlchemy()
 migrate = Migrate()
+oidc = OpenIDConnect()

--- a/Webapp/sources/templates/auth/login.html
+++ b/Webapp/sources/templates/auth/login.html
@@ -24,7 +24,8 @@
         <br>
         {% endfor %}
         {{ form.remember_me() }} {{ form.remember_me.label }}<br>
-        {{ form.submit() }}
+        {{ form.submit() }}<br>
+        <a class="btn btn-link" id="sso" href="{{ url_for('auth.oidc_login') }}">Use Single Sign-on</a>
     </form>
 </div>
     New User? <a id="register" class="btn btn-link" href="{{ url_for('auth.register') }}">Click to Register!</a><br>

--- a/Webapp/sources/templates/general/landing_page.html
+++ b/Webapp/sources/templates/general/landing_page.html
@@ -54,6 +54,12 @@
                                 Click to Register 🌱
                               </a>
                             </p>
+                            <p>
+                                <a id="register" class="btn btn-light text-dark shadow-lg fw-bold px-4 py-2 rounded-pill text-decoration-none"
+                                   href="{{ url_for('auth.oidc_login') }}">
+                                  Use Single Sign-on
+                                </a>
+                              </p>
                         </div>
                     </div>
                 </div>

--- a/poetry.lock
+++ b/poetry.lock
@@ -223,6 +223,20 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "authlib"
+version = "1.5.2"
+description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "authlib-1.5.2-py2.py3-none-any.whl", hash = "sha256:8804dd4402ac5e4a0435ac49e0b6e19e395357cfa632a3f624dcb4f6df13b4b1"},
+    {file = "authlib-1.5.2.tar.gz", hash = "sha256:fe85ec7e50c5f86f1e2603518bb3b4f632985eb4a355e52256530790e326c512"},
+]
+
+[package.dependencies]
+cryptography = "*"
+
+[[package]]
 name = "azure-core"
 version = "1.32.0"
 description = "Microsoft Azure Core Library for Python"
@@ -1150,6 +1164,23 @@ Flask-SQLAlchemy = ">=1.0"
 [package.extras]
 dev = ["flake8", "pytest", "tox"]
 docs = ["sphinx"]
+
+[[package]]
+name = "flask-oidc"
+version = "2.3.1"
+description = "OpenID Connect extension for Flask"
+optional = false
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "flask_oidc-2.3.1-py3-none-any.whl", hash = "sha256:ecf04a79fe27410e111ff861a40ec63ce73d641deecddad91b68fbae6f06f733"},
+    {file = "flask_oidc-2.3.1.tar.gz", hash = "sha256:f30f64549a14a622cbd427232ea535c85b3b1c33576c5270ae0e531c31ec0088"},
+]
+
+[package.dependencies]
+authlib = ">=1.2.0,<2.0.0"
+blinker = ">=1.4.0,<2.0.0"
+flask = ">=0.12.2,<4.0.0"
+requests = ">=2.20.0,<3.0.0"
 
 [[package]]
 name = "flask-sqlalchemy"
@@ -3986,4 +4017,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "6db4fa5335e4a836179a09326d1168a691be84027c8f05b1e184369292af103a"
+content-hash = "5ee374e922310fd1064cf5658b8b22914cb2aa09de73558b2fa06e925f5005d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ odfpy =  "^1.4.1"
 qrcode = "^7.4.2"
 psmiles = {git = "https://github.com/Ramprasad-Group/psmiles.git"}
 ipinfo = "^5.1.1"
+flask-oidc = "^2.3.1"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
# Overview

- Install Flask-OIDC package
- Add new config values to `Webapp/sources/config.py` to enable OIDC compatibility
  - `OIDC_CLIENT_ID`: the client ID of the OIDC provider
  - `OIDC_CLIENT_SECRET`: the client secret of the OIDC provider
  - `OIDC_AUTH_URI`: the authorisation URI for the OIDC provider
  - `OIDC_TOKEN_URI`: token endpoint for the OIDC provider
  - `OIDC_USERINFO_URI`: user info endpoint for the OIDC provider
  - `OIDC_ISSUER`: the issuer URI for the OIDC provider
  - `OIDC_REDIRECT_URIS`: comma-separated list of valid redirect URIs for the OIDC provider ("uri1,uri2,...")
- Add two new routs for OIDC compatibility
  - `/auth/oidc_login`: redirects the user to the OIDC provider
  - `/auth/oidc_callback`: when the user has finished signing in/up with the OIDC provider, log the user into AI4Green
- Modify logout route to check if a user is logged in using OIDC, if so, log out with the OIDC provider
- Add links to landing page and login page to direct users to OIDC login (Single Sign-on)

## Azure Boards

- [AB#199415](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/199415)
- [AB#199418](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/199418)
