### PR TITLE
AB#213755: Try `_external=True` for full redirect URI

### DIFF
--- a/Webapp/sources/blueprints/auth/routes.py
+++ b/Webapp/sources/blueprints/auth/routes.py
@@ -125,7 +125,7 @@ def oidc_login() -> Response:
     Returns:
         Response: redirect to the OIDC login page.
     """
-    return oidc.redirect_to_auth_server(url_for("auth.oidc_callback"))
+    return oidc.redirect_to_auth_server(url_for("auth.oidc_callback", _external=True))
 
 
 @auth_bp.route("/authorize")


### PR DESCRIPTION
# Overview

- Try getting `url_for` to generate a full URI so it should is the scheme (https) and hostname in the redirect uri to OIDC provider

## Azure Boards

- [AB#213755](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/213755)
