### PR TITLE
AB#214415: Bugfix/kafka producer breaks cicd

### DIFF
--- a/Webapp/sources/__init__.py
+++ b/Webapp/sources/__init__.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 from apiflask import APIFlask
 from flask import Flask
-from sources.services.message_queue import QueueProducer
+from sources.services.message_queue import LoggingQueueProducer, QueueProducer
 from sources import config, models
 from sources.auxiliary import get_notification_number, get_workgroups
 from sources.extensions import db, login, ma, mail, migrate, oidc
@@ -97,8 +97,16 @@ def register_extensions(app: Flask) -> None:
         return models.User.query.get(user_id)
 
     # configure the message queue, e.g. kafka
-    # producer = QueueProducer(**app.config["MESSAGE_QUEUE_CONFIG"])
-    # app.config["MESSAGE_QUEUE_PRODUCER"] = producer
+    if app.config.get("USE_KAFKA", False):
+        # In production or situations where Kafka is required,
+        # use the kafka queue producer.
+        # N.B. reuqires the kafka services to be running!
+        producer = QueueProducer(**app.config["MESSAGE_QUEUE_CONFIG"])
+    else:
+        # Use a queue producer which sends messages to the standard output
+        # via the built-in logger in Flask.
+        producer = LoggingQueueProducer()
+    app.config["MESSAGE_QUEUE_PRODUCER"] = producer
 
     mail.init_app(app)
 

--- a/Webapp/sources/config.py
+++ b/Webapp/sources/config.py
@@ -158,6 +158,8 @@ class BaseConfig(object):  # class to store configuration variables
         "hostname": os.getenv("MESSAGE_QUEUE_HOSTNAME", "localhost:9092")
     }
 
+    USE_KAFKA = bool(os.getenv("USE_KAFKA", False))
+
 
 class TestConfig(BaseConfig):
     TESTING = True

--- a/Webapp/sources/services/message_queue.py
+++ b/Webapp/sources/services/message_queue.py
@@ -1,10 +1,21 @@
 import json
-import socket
-from flask import current_app
+from typing import Any, Optional
 from kafka import KafkaProducer
 
 
-class QueueProducer:
+class BaseQueueProducer:
+
+    def send(self, topic: Optional[str] = None, msg: Optional[Any] = None):
+        """Send a message to the message queue with the given topic.
+
+        Args:
+            topic (Optional[str]): The topic to send the message to.
+            msg (Optional[Any]): The message to send to the queue.
+        """
+        raise NotImplementedError
+
+
+class QueueProducer(BaseQueueProducer):
     """This class is a service which is used to send messages to a kafka cluster."""
 
     def __init__(self, hostname: str):
@@ -22,12 +33,12 @@ class QueueProducer:
             # client_id="daniel", TODO: find a good value for the client id
         )
 
-    def send(self, topic: str, msg: dict):
+    def send(self, topic: Optional[str] = None, msg: Optional[Any] = None):
         """Send a message to the message queue with the given topic.
 
         Args:
-            topic (str): The topic to send the message to.
-            msg (dict): The message to send to the queue.
+            topic (Optional[str]): The topic to send the message to.
+            msg (Optional[Any]): The message to send to the queue.
         """
         self.producer.send(topic, value=msg)
         self.producer.flush()

--- a/Webapp/sources/services/message_queue.py
+++ b/Webapp/sources/services/message_queue.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Optional
+from flask import current_app
 from kafka import KafkaProducer
 
 
@@ -37,8 +38,27 @@ class QueueProducer(BaseQueueProducer):
         """Send a message to the message queue with the given topic.
 
         Args:
-            topic (Optional[str]): The topic to send the message to.
-            msg (Optional[Any]): The message to send to the queue.
+            topic (str, optional): The topic to send the message to.
+            msg (Any, optional): The message to send to the queue.
         """
         self.producer.send(topic, value=msg)
         self.producer.flush()
+
+
+class LoggingQueueProducer(BaseQueueProducer):
+    """
+    A queue producer designed to be used in testing situations where
+    actually sending messages to a message queue is not required.
+
+    This producer simply logs the messages with the Flask logger instance.
+    """
+
+    def send(self, topic: Optional[str] = None, msg: Optional[Any] = None):
+        """Send a message to the standard output using the built-in logger
+        in Flask.
+
+        Args:
+            topic (str, optional): This is ignored in this class. Defaults to None.
+            msg (Any, optional): The message to send to the queue. Defaults to None.
+        """
+        current_app.logger.info(msg=msg)

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,9 @@ flask db upgrade # update the database
 ```
 
 ### Apache Kafka
-The `docker-compose.yaml` file contains the `kafka` service (which is supported by `zookerper`) and the `kafka-ui` service. `kafka-ui` can be used to set up a cluster and topics in the browser at http://localhost:8080.
+The `docker-compose.yaml` file contains the `kafka` service (which is supported by `zookerper`) and the `kafka-ui` service. `kafka-ui` can be used to set up a cluster and topics in the browser at http://localhost:8080. 
+
+**When using Kafka, make sure you set the environment variable `USE_KAFKA` to 1. Otherwise messages will be logged to the standard output. This behaviour is only for testing purposes where a Kafka instance is not required.**
 
 When you first start the services and navigate to the `kafka-ui` in the browser, you will be asked to configure a cluster. Enter a name in the "Cluster name" field, then under "Bootstrap Servers", enter "kafka" in the "Host" field and 29092 in the "Port" field. Click the "Validate" button to make sure it's working, then click "Submit" if you get the green dialog box.
 


### PR DESCRIPTION
# Overview

- Create a mock queue producer that does not require a running kafka instance in CI/CD pipelines
- Use that if the app is set to not use Kafka
- Update kafka guidance to explain how to use the mock producer

## Azure Boards

- [AB#214417](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/214417)
- [AB#214416](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/214416)
