### PR TITLE
AB#216542: don't copy non existent script

### DIFF
--- a/microservices/kafka-connect.dockerfile
+++ b/microservices/kafka-connect.dockerfile
@@ -28,8 +28,4 @@ RUN mkdir -p /etc/kafka-connect/jars
 COPY confluentinc-kafka-connect-s3-10.6.7.zip /tmp/s3-sink-connector.zip
 RUN unzip /tmp/s3-sink-connector.zip -d /etc/kafka-connect/jars && rm /tmp/s3-sink-connector.zip
 
-# Copy the custom entrypoint script
-COPY kafka-connect-setup.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
 # Kafka Connect will start as normal with the S3 sink plugin loaded


### PR DESCRIPTION
# Overview

- Remove line to copy and execute a non-existent custom start-up script in KC dockerfile

## Azure Boards

- [AB#216542](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/216542)
