### PR TITLE
AB#217330: rename webapp publish workflow

### DIFF
--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -1,4 +1,4 @@
-name: Release AI4Green MinIO
+name: Release AI4Green Webapp
 
 on:
   push:


### PR DESCRIPTION
# Overview

Change `name` field of the webapp workflow to say "Webapp" not "MinIO"

## Azure Boards

- [AB#217330](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/217330)
