### PR TITLE
AB#218509: specify app in startup.sh

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -7,7 +7,7 @@ apt install libxrender1 -y
 apt install libmagic-dev -y
 
 # Run migrations
-flask db upgrade --directory Webapp/migrations
+flask --app Webapp/app.py db upgrade --directory Webapp/migrations
 
 # Run server
 gunicorn "Webapp.sources:create_app('prod')" --bind=0.0.0.0 --timeout 600 --chdir ./Webapp


### PR DESCRIPTION
# Overview

- Migrations weren't running in UAT
- Got the following error in portal logs:

> 2025-08-13T15:31:28.5534692Z Error: Could not locate a Flask application. Use the 'flask --app' option, 'FLASK_APP' environment variable, or a 'wsgi.py' or 'app.py' file in the current directory.

> 2025-08-13T15:31:28.5535685Z

> 2025-08-13T15:31:28.5553612Z Usage: flask [OPTIONS] COMMAND [ARGS]...

> 2025-08-13T15:31:28.5553922Z Try 'flask --help' for help.

> 2025-08-13T15:31:28.5553961Z

> 2025-08-13T15:31:28.5555947Z Error: No such command 'db'.

- Update migration command to specify path to `app.py`

## Azure Boards

- [AB#218509](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/218509)
