### PR TITLE
AB#218564: pass the client to _clear_messages; change docstring

### DIFF
--- a/Webapp/sources/services/message_queue/consumers.py
+++ b/Webapp/sources/services/message_queue/consumers.py
@@ -1,7 +1,7 @@
 import json
 import time
 from typing import List
-from azure.storage.queue import QueueServiceClient, QueueMessage
+from azure.storage.queue import QueueClient, QueueServiceClient, QueueMessage
 from kafka import KafkaConsumer
 
 
@@ -99,13 +99,12 @@ class AzureQueueConsumer(BaseQueueConsumer):
 
         return messages
 
-    def _clear_messages(self, sc: QueueServiceClient, messages: List[QueueMessage]):
+    def _clear_messages(self, client: QueueClient, messages: List[QueueMessage]):
         """Delete messages from the Azure Queue Storage.
 
         Args:
-            sc (QueueServiceClient): The service client for Azure Queue Storage.
+            client (QueueClient): The client for Azure Queue Storage.
             messages (List[QueueMessage]): The list of messages to delete.
         """
-        client = sc.get_queue_client(self.queue_name)
         for message in messages:
             client.delete_message(message)


### PR DESCRIPTION
# Overview

Pass the client object rather than the service client to `_clear_messages` in the Azure queue consumer.

## Azure Boards

- [AB#218564](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/218564)
