### PR TITLE
AB#218711: change queue names to avoid audit log download weirdness

### DIFF
--- a/Webapp/sources/services/reaction_editing_history.py
+++ b/Webapp/sources/services/reaction_editing_history.py
@@ -60,7 +60,7 @@ def send_message(message: ReactionEditMessage):
     """
     producer = current_app.config["MESSAGE_QUEUE_PRODUCER"]
     # topic name can only be letters and numbers
-    producer.send("reaction-editing-history", message.serialise())
+    producer.send("reaction-editing-history-raw", message.serialise())
 
 
 def add_new_reaction(person, workbook, reaction_id, reaction_name):

--- a/Webapp/sources/templates/work_structures/manage_workgroup.html
+++ b/Webapp/sources/templates/work_structures/manage_workgroup.html
@@ -398,7 +398,7 @@
                             <div class="mb-4">
                                 <label class="form-label mb-2" style="font-weight: 600;">Topic:</label><br>
                                 <div class="form-check form-check-inline">
-                                    <input class="form-check-input" type="radio" name="topic" id="reaction-history" value="reaction-editing-history-compressed" checked>
+                                    <input class="form-check-input" type="radio" name="topic" id="reaction-history" value="reaction-editing-history" checked>
                                     <label class="form-check-label" for="reaction-history">Reaction Edit History</label>
                                 </div>
                                 <div class="form-check form-check-inline">

--- a/workers/audit_log_compressor/config.py
+++ b/workers/audit_log_compressor/config.py
@@ -7,8 +7,8 @@ load_dotenv()
 
 # message queue config
 QUEUE_CONNECTION_STRING = os.getenv("QUEUE_CONNECTION_STRING", "localhost:9092")
-CONSUME_TOPIC = os.getenv("CONSUME_TOPIC", "reaction-editing-history")
-PRODUCE_TOPIC = os.getenv("PRODUCE_TOPIC", "reaction-editing-history-compressed")
+CONSUME_TOPIC = os.getenv("CONSUME_TOPIC", "reaction-editing-history-raw")
+PRODUCE_TOPIC = os.getenv("PRODUCE_TOPIC", "reaction-editing-history")
 
 # Polling config
 POLL_INTERVAL_MINS = int(os.getenv("POLL_INTERVAL_MINS", 60))


### PR DESCRIPTION
# Overview

- Change the names of reaction edit history queues so the logs that get saved appear as "reaction_editing_history"

## Azure Boards

- [AB#218711](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/218711)
