### PR TITLE
AB#234607: fix: prevent ring bonds being broken in canonicalise()

### DIFF
--- a/Webapp/sources/services/polymer_novel_compound.py
+++ b/Webapp/sources/services/polymer_novel_compound.py
@@ -569,6 +569,11 @@ def get_repeating_substructure(mol):
 
     for ring in ssr:
         ring_indices = sorted(list(ring))
+
+        # ignore original rings
+        if all(mol.GetAtomWithIdx(idx).HasProp('ring') for idx in ring_indices):
+            continue
+
         n = len(ring_indices)
         ring_ranks = [ranks[i] for i in ring_indices]
 
@@ -620,6 +625,10 @@ def get_repeating_substructure(mol):
                     # If neighbor is in the ring but NOT in our current repeating unit
                     if nb_idx in other_ring_atoms:
                         exit_bonds.append((atom_idx, nb_idx))
+
+            # do not break original ring bonds
+            if any([rw_mol.GetBondBetweenAtoms(stay_idx, leave_idx).HasProp('ring') for stay_idx, leave_idx in exit_bonds]):
+                continue
 
             # Add dummy atoms at the exit points
             for stay_idx, leave_idx in exit_bonds:
@@ -737,6 +746,11 @@ def canonicalise(unit):
     # check if all bonds are in rings - these shouldnt be cyclised
     if all_ring_bonds(mol):
         return Chem.MolToSmiles(mol)
+
+    # Identify atoms in rings
+    for atom in mol.GetAtoms():
+        if atom.IsInRing():
+            atom.SetProp("ring", "True")
 
     # Create the cyclic version
     cyclic_mol = Chem.RWMol(mol)

--- a/Webapp/sources/services/polymer_novel_compound.py
+++ b/Webapp/sources/services/polymer_novel_compound.py
@@ -569,12 +569,22 @@ def get_repeating_substructure(mol):
 
     for ring in ssr:
         ring_indices = sorted(list(ring))
+        n = len(ring_indices)
 
-        # ignore original rings
-        if all(mol.GetAtomWithIdx(idx).HasProp('ring') for idx in ring_indices):
+        # only process the ring that contains the macrocycle closure bond
+        has_closure_bond = False
+        for i in range(n):
+            idx1 = ring_indices[i]
+            idx2 = ring_indices[(i + 1) % n]
+            bond = mol.GetBondBetweenAtoms(idx1, idx2)
+            if bond and bond.HasProp('closure'):
+                has_closure_bond = True
+                break
+
+        # If this ring doesn't contain the closure bond, it's a monomer ring (like Benzene). Skip it.
+        if not has_closure_bond:
             continue
 
-        n = len(ring_indices)
         ring_ranks = [ranks[i] for i in ring_indices]
 
         # Find smallest repeating period, i, to divide length n perfectly
@@ -747,14 +757,11 @@ def canonicalise(unit):
     if all_ring_bonds(mol):
         return Chem.MolToSmiles(mol)
 
-    # Identify atoms in rings
-    for atom in mol.GetAtoms():
-        if atom.IsInRing():
-            atom.SetProp("ring", "True")
-
     # Create the cyclic version
     cyclic_mol = Chem.RWMol(mol)
-    cyclic_mol.AddBond(anchors[0], anchors[1], bond_type)
+    num_bonds = cyclic_mol.AddBond(anchors[0], anchors[1], bond_type)
+    closure_bond = cyclic_mol.GetBondWithIdx(num_bonds - 1)
+    closure_bond.SetProp('closure', "True")
 
     # Remove dummies in reverse order to keep indices stable
     for idx in sorted(dummy_indices, reverse=True):

--- a/Webapp/tests/services/test_novel_compound.py
+++ b/Webapp/tests/services/test_novel_compound.py
@@ -193,6 +193,7 @@ def test_polymer_smiles_parsing():
     assert find_canonical_repeats("*C1{-}(CCCCC1)C1(CCCCC1)C1{+n}(CCCCC1)*") == [
         "*C1(*)CCCCC1"
     ]
+    assert find_canonical_repeats("*C1{-}=CC=C(C=C1)/C=C{+n}/*") == ['*C=Cc1ccc(*)cc1'] # dont reduce
 
     # double bonds to dummy atoms
     assert find_canonical_repeats("*=C{-}(NC1:C:C:C(:C:C:1)C1:C:C:C(:C:C:1)N{+n}=*)C") == [


### PR DESCRIPTION
# Overview

prevent ring bonds being broken when reducing multiplication of polymer smiles strings

## Azure Boards

- [AB#234607](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/234607)
