### PR TITLE
AB#245409: added text to polymer summary table

### DIFF
--- a/Webapp/sources/templates/reactions/_polymer_summary_table.html
+++ b/Webapp/sources/templates/reactions/_polymer_summary_table.html
@@ -1,6 +1,11 @@
 {% from "macros/modals.html" import toxicity_modal, suggest_comment_modal, reject_reaction_modal %}
 
 <div id="section-to-print">
+    <div>
+        <p>
+            <label for="js-reaction-description-summary"></label><textarea id="js-reaction-description-summary"  style="width: 100%; box-sizing: border-box" disabled placeholder="Please describe your reaction">{{ reaction_description }}</textarea>
+        </p>
+    </div>
 <table class="table table-sm">
     <!-- Define column widths -->
     <colgroup>


### PR DESCRIPTION
# Overview

Added text box to summary table for printing to pdf. WAs left off last PR

## Azure Boards

- [AB#245409](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/245409)
